### PR TITLE
fix(core)!: IEventQueue TryDequeue out parameter is not async compatible

### DIFF
--- a/samples/01.simple/InMemoryEventQueue.cs
+++ b/samples/01.simple/InMemoryEventQueue.cs
@@ -1,7 +1,6 @@
 namespace Usain.Samples.Simple
 {
     using System.Collections.Concurrent;
-    using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;
     using Core.Infrastructure;
@@ -20,9 +19,11 @@ namespace Usain.Samples.Simple
             return Task.CompletedTask;
         }
 
-        public Task<bool> TryDequeueAsync(
-            [NotNullWhen(true)] out EventWrapper item,
+        public Task<EventWrapper> DequeueAsync(
             CancellationToken cancellationToken = default)
-            => Task.FromResult(_queue.TryDequeue(out item));
+        {
+            _queue.TryDequeue(out var item);
+            return Task.FromResult(item);
+        }
     }
 }

--- a/src/Usain.Core/Infrastructure/IEventQueue.cs
+++ b/src/Usain.Core/Infrastructure/IEventQueue.cs
@@ -9,8 +9,6 @@ namespace Usain.Core.Infrastructure
         Task EnqueueAsync(
             [NotNull] TItem item, CancellationToken cancellationToken);
 
-        Task<bool> TryDequeueAsync(
-            [NotNullWhen(true)] out TItem item,
-            CancellationToken cancellationToken);
+        Task<TItem> DequeueAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Usain.EventProcessor/HostedServices/EventQueueProcessor.cs
+++ b/src/Usain.EventProcessor/HostedServices/EventQueueProcessor.cs
@@ -31,9 +31,8 @@ namespace Usain.EventProcessor.HostedServices
             CancellationToken cancellationToken)
         {
             _logger.LogProcessingQueue();
-            if (await _eventQueue.TryDequeueAsync(
-                out var @event,
-                cancellationToken))
+            var @event = await _eventQueue.DequeueAsync(cancellationToken);
+            if(@event != null)
             {
                 _logger.LogEventHasBeenDequeued(@event?.Type ?? string.Empty);
                 await ReactToEventAsync(@event);

--- a/tests/Usain.EventProcessor.Tests/DependencyInjection/EventProcessorBuilderExtensionsTest.cs
+++ b/tests/Usain.EventProcessor.Tests/DependencyInjection/EventProcessorBuilderExtensionsTest.cs
@@ -128,8 +128,7 @@ namespace Usain.EventProcessor.Tests.DependencyInjection
                 CancellationToken cancellationToken)
                 => throw new NotImplementedException();
 
-            public Task<bool> TryDequeueAsync(
-                out EventWrapper item,
+            public Task<EventWrapper> DequeueAsync(
                 CancellationToken cancellationToken)
                 => throw new NotImplementedException();
         }
@@ -141,8 +140,7 @@ namespace Usain.EventProcessor.Tests.DependencyInjection
                 CancellationToken cancellationToken)
                 => throw new NotImplementedException();
 
-            public Task<bool> TryDequeueAsync(
-                out EventWrapper item,
+            public Task<EventWrapper> DequeueAsync(
                 CancellationToken cancellationToken)
                 => throw new NotImplementedException();
         }

--- a/tests/Usain.EventProcessor.Tests/HostedServices/EventQueueProcessorTest.cs
+++ b/tests/Usain.EventProcessor.Tests/HostedServices/EventQueueProcessorTest.cs
@@ -32,10 +32,9 @@ namespace Usain.EventProcessor.Tests.HostedServices
                 .Setup(x => x.Generate(_eventWrapper))
                 .Returns(_reactionMock.Object);
             _eventQueueMock.Setup(
-                    x => x.TryDequeueAsync(
-                        out _eventWrapper,
+                    x => x.DequeueAsync(
                         It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(true));
+                .Returns(Task.FromResult(_eventWrapper));
         }
 
         [Fact]
@@ -54,10 +53,8 @@ namespace Usain.EventProcessor.Tests.HostedServices
         {
             _eventWrapper = new EventWrapper(); // EventWrapper's Event property is not set
             _eventQueueMock.Setup(
-                    x => x.TryDequeueAsync(
-                        out _eventWrapper,
-                        It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(true));
+                    x => x.DequeueAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(_eventWrapper));
 
             var queueProcessor = CreateEventQueueProcessor();
             await queueProcessor.ProcessQueueAsync(CancellationToken.None);


### PR DESCRIPTION
Remove out parameter from the IEventQueue.TryDequeue method signature.
This signature wasn't compatible with an async usage.

see https://tinyurl.com/y7movd5q for more info.

__BREAKING CHANGE__

`IEventQueue.TryDequeueAsync` has changed to return the dequeued item rather than a boolean.