### PR TITLE
doc(samples): add advanced AzureQueue sample

### DIFF
--- a/Usain.sln
+++ b/Usain.sln
@@ -42,6 +42,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "User.Slack.Tests", "tests\U
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Usain.EventListener.Tests", "tests\Usain.EventListener.Tests\Usain.EventListener.Tests.csproj", "{9F9F3D71-44AA-4A6F-A2A0-FFBCCB9FF3EB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "02.advanced.azurequeue", "02.advanced.azurequeue", "{E1B53DF8-DFB8-4CE5-B038-0ECE9F831969}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Usain.Samples.Advanced.AzureQueue.EventListener", "samples\02.advanced.azurequeue\Usain.Samples.Advanced.AzureQueue.EventListener\Usain.Samples.Advanced.AzureQueue.EventListener.csproj", "{66320251-BA9F-4488-83A8-A7CD5C0DCB94}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Usain.Samples.Advanced.AzureQueue.EventProcessor", "samples\02.advanced.azurequeue\Usain.Samples.Advanced.AzureQueue.EventProcessor\Usain.Samples.Advanced.AzureQueue.EventProcessor.csproj", "{7562425E-6297-48DF-951D-41D255926853}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Usain.Samples.Advanced.AzureQueue.Common", "samples\02.advanced.azurequeue\Usain.Samples.Advanced.AzureQueue.Common\Usain.Samples.Advanced.AzureQueue.Common.csproj", "{12B79AFA-FDDA-487D-8FD0-1620AD2AF472}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -163,6 +171,42 @@ Global
 		{9F9F3D71-44AA-4A6F-A2A0-FFBCCB9FF3EB}.Release|x64.Build.0 = Release|Any CPU
 		{9F9F3D71-44AA-4A6F-A2A0-FFBCCB9FF3EB}.Release|x86.ActiveCfg = Release|Any CPU
 		{9F9F3D71-44AA-4A6F-A2A0-FFBCCB9FF3EB}.Release|x86.Build.0 = Release|Any CPU
+		{66320251-BA9F-4488-83A8-A7CD5C0DCB94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{66320251-BA9F-4488-83A8-A7CD5C0DCB94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{66320251-BA9F-4488-83A8-A7CD5C0DCB94}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{66320251-BA9F-4488-83A8-A7CD5C0DCB94}.Debug|x64.Build.0 = Debug|Any CPU
+		{66320251-BA9F-4488-83A8-A7CD5C0DCB94}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{66320251-BA9F-4488-83A8-A7CD5C0DCB94}.Debug|x86.Build.0 = Debug|Any CPU
+		{66320251-BA9F-4488-83A8-A7CD5C0DCB94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{66320251-BA9F-4488-83A8-A7CD5C0DCB94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{66320251-BA9F-4488-83A8-A7CD5C0DCB94}.Release|x64.ActiveCfg = Release|Any CPU
+		{66320251-BA9F-4488-83A8-A7CD5C0DCB94}.Release|x64.Build.0 = Release|Any CPU
+		{66320251-BA9F-4488-83A8-A7CD5C0DCB94}.Release|x86.ActiveCfg = Release|Any CPU
+		{66320251-BA9F-4488-83A8-A7CD5C0DCB94}.Release|x86.Build.0 = Release|Any CPU
+		{7562425E-6297-48DF-951D-41D255926853}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7562425E-6297-48DF-951D-41D255926853}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7562425E-6297-48DF-951D-41D255926853}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7562425E-6297-48DF-951D-41D255926853}.Debug|x64.Build.0 = Debug|Any CPU
+		{7562425E-6297-48DF-951D-41D255926853}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7562425E-6297-48DF-951D-41D255926853}.Debug|x86.Build.0 = Debug|Any CPU
+		{7562425E-6297-48DF-951D-41D255926853}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7562425E-6297-48DF-951D-41D255926853}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7562425E-6297-48DF-951D-41D255926853}.Release|x64.ActiveCfg = Release|Any CPU
+		{7562425E-6297-48DF-951D-41D255926853}.Release|x64.Build.0 = Release|Any CPU
+		{7562425E-6297-48DF-951D-41D255926853}.Release|x86.ActiveCfg = Release|Any CPU
+		{7562425E-6297-48DF-951D-41D255926853}.Release|x86.Build.0 = Release|Any CPU
+		{12B79AFA-FDDA-487D-8FD0-1620AD2AF472}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12B79AFA-FDDA-487D-8FD0-1620AD2AF472}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12B79AFA-FDDA-487D-8FD0-1620AD2AF472}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{12B79AFA-FDDA-487D-8FD0-1620AD2AF472}.Debug|x64.Build.0 = Debug|Any CPU
+		{12B79AFA-FDDA-487D-8FD0-1620AD2AF472}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{12B79AFA-FDDA-487D-8FD0-1620AD2AF472}.Debug|x86.Build.0 = Debug|Any CPU
+		{12B79AFA-FDDA-487D-8FD0-1620AD2AF472}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12B79AFA-FDDA-487D-8FD0-1620AD2AF472}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12B79AFA-FDDA-487D-8FD0-1620AD2AF472}.Release|x64.ActiveCfg = Release|Any CPU
+		{12B79AFA-FDDA-487D-8FD0-1620AD2AF472}.Release|x64.Build.0 = Release|Any CPU
+		{12B79AFA-FDDA-487D-8FD0-1620AD2AF472}.Release|x86.ActiveCfg = Release|Any CPU
+		{12B79AFA-FDDA-487D-8FD0-1620AD2AF472}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{3742C6E9-5AC8-4D9E-8CD4-1FD168E42AC4} = {E239EA52-2AF7-4693-A823-D4342003FF80}
@@ -175,5 +219,9 @@ Global
 		{B4FF45FB-D045-4F0D-9527-239B0AA5DA96} = {14285CE1-3C32-4448-9997-ED0ACE76B422}
 		{1AA917EA-1A57-48C0-B9D8-EA6032536BE6} = {14285CE1-3C32-4448-9997-ED0ACE76B422}
 		{9F9F3D71-44AA-4A6F-A2A0-FFBCCB9FF3EB} = {14285CE1-3C32-4448-9997-ED0ACE76B422}
+		{E1B53DF8-DFB8-4CE5-B038-0ECE9F831969} = {28D7CC68-9DE7-4DE7-BDF5-DC2DFC260C79}
+		{66320251-BA9F-4488-83A8-A7CD5C0DCB94} = {E1B53DF8-DFB8-4CE5-B038-0ECE9F831969}
+		{7562425E-6297-48DF-951D-41D255926853} = {E1B53DF8-DFB8-4CE5-B038-0ECE9F831969}
+		{12B79AFA-FDDA-487D-8FD0-1620AD2AF472} = {E1B53DF8-DFB8-4CE5-B038-0ECE9F831969}
 	EndGlobalSection
 EndGlobal

--- a/props/dependencies.props
+++ b/props/dependencies.props
@@ -7,6 +7,10 @@
     <XUnitRunnerVersion>2.4.2</XUnitRunnerVersion>
     <TestSdkVersion>16.6.1</TestSdkVersion>
     <MoqVersion>4.14.4</MoqVersion>
+    <MicrosoftExtensionsConfigurationVersion>3.1.5</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsLoggingVersion>3.1.5</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsHostingVersion>3.1.5</MicrosoftExtensionsHostingVersion>
+    <AzureStorageQueuesVersion>12.3.2</AzureStorageQueuesVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/01.simple/UsainReactions/AppMentionEventReaction.cs
+++ b/samples/01.simple/UsainReactions/AppMentionEventReaction.cs
@@ -13,9 +13,9 @@ namespace Usain.Samples.Simple.UsainReactions
     {
         private readonly string[] _greetings = {
             "Hi <@{0}>! What's going on ?",
-            "How's it going <@{0}>?",
-            "Good to see you <@{0}>?",
-            "It’s been a while <@{0}>!",
+            "How's it going <@{0}> ?",
+            "Good to see you <@{0}>, it's been a while !",
+            "How can i help you <@{0}> ?",
         };
 
         public AppMentionEventReaction(

--- a/samples/02.advanced.azurequeue/README.md
+++ b/samples/02.advanced.azurequeue/README.md
@@ -1,0 +1,56 @@
+# Usain Samples - Advanced - Azure Queue
+
+## Introduction
+
+## Two hosts
+This sample demonstrates how to run an EventListener and an EventProcessor in two different hosts.
+
+
+* EventListener: hosted in a WebHost (ASP.NET Core)
+* EventProcessor: hosted in a generic Host (Console App)
+
+Both rely on the [HostBuilder] infrastructure.
+A host is an object that encapsulates an app's resources, such as:
+
+* Dependency injection (DI)
+* Logging
+* Configuration
+* IHostedService implementations
+
+When a host starts, it calls IHostedService.StartAsync on each implementation of IHostedService registered in the service container's collection of hosted services.
+
+This part is useful for us because UsainEventProcessor main processing task is an implementation of the IHostedService interface.
+
+## Azure Queue
+The listener and the processor exchange background work (event to process) throught the [IEventQueue] interface.\
+In that sample, we use an [Azure Queue] as the main queue infrastructure.
+
+[AzureQueueWrapper] class implements the IEventQueue interface. It is a wrapper around an Azure QueueClient.
+
+# Getting started
+
+To run that sample, you need to create an Azure Storage Account and retrieve the Storage connection string.
+Use that connection string to udpdate the value of the AzureQueue:ConnectionString settings in the appsettings.json file of the EventListener and the EventProcessor.
+
+You can then run them both in 2 terminals:
+
+_Terminal 1_
+
+```shell
+cd ./samples/O2.advanced.azurequeue
+dotnet run -p Usain.Samples.Advanced.AzureQueue.EventListener
+```
+_Terminal 2_
+
+```shell
+cd ./samples/O2.advanced.azurequeue
+dotnet run -p Usain.Samples.Advanced.AzureQueue.EventProcessor
+```
+
+[HostBuilder]: <https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-3.1>
+[IEventQueue]: <../../src/Usain.Core/Infrastructure/IEventQueue.cs>
+[Azure Queue]: <https://docs.microsoft.com/en-us/azure/storage/queues/storage-queues-introduction>
+[AzureQueueWrapper]: <Usain.Samples.Advanced.AzureQueue.Common/AzureQueueWrapper.cs>
+
+
+

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.Common/AzureQueueConnectionStringValidator.cs
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.Common/AzureQueueConnectionStringValidator.cs
@@ -1,0 +1,45 @@
+namespace Usain.Samples.Advanced.AzureQueue.Common
+{
+    using System;
+    using Azure.Storage.Queues;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+
+    // Azure StorageConnectionString is now internal ..
+    // we don't have access to Azure SDK internal validation logic (eg. StorageConnectionString.Parse)
+    // This class just serves as a fast fail check when validating options
+    // rather than waiting for a AzureQueueClient instance initialization (late in the pipeline)
+    // Please don't use that in production
+    public class AzureQueueConnectionStringValidator
+        : IAzureQueueConnectionStringValidator
+    {
+        private const string ErrorMessage =
+            "Azure Queue connection string is not valid. Check your configuration";
+        private readonly ILogger _logger;
+
+        public AzureQueueConnectionStringValidator(
+            ILogger<AzureQueueConnectionStringValidator> logger)
+            => _logger = logger;
+
+        public ValidateOptionsResult Validate(
+            string connectionString,
+            string queueName)
+        {
+            try
+            {
+                new QueueClient(
+                    connectionString,
+                    queueName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    ErrorMessage);
+                return ValidateOptionsResult.Fail(ErrorMessage);
+            }
+
+            return ValidateOptionsResult.Success;
+        }
+    }
+}

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.Common/AzureQueueOptions.cs
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.Common/AzureQueueOptions.cs
@@ -1,0 +1,49 @@
+namespace Usain.Samples.Advanced.AzureQueue.Common
+{
+    using System;
+    using System.ComponentModel.DataAnnotations;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Options;
+
+    public class AzureQueueOptions : IConfigureOptions<AzureQueueOptions>,
+        IValidateOptions<AzureQueueOptions>
+    {
+        private const string OptionsSectionKeyName = "AzureQueue";
+        private readonly IConfiguration _configuration;
+        private readonly IAzureQueueConnectionStringValidator
+            _connectionStringValidator;
+
+        [Required]
+        public string ConnectionString { get; set; }
+
+        [Required]
+        public string QueueName { get; set; }
+
+        public AzureQueueOptions() { }
+
+        public AzureQueueOptions(
+            IConfiguration configuration,
+            IAzureQueueConnectionStringValidator connectionStringValidator)
+        {
+            _configuration = configuration
+                ?? throw new ArgumentNullException(nameof(configuration));
+            _connectionStringValidator = connectionStringValidator
+                ?? throw new ArgumentNullException(
+                    nameof(connectionStringValidator));
+        }
+
+        public void Configure(
+            AzureQueueOptions options)
+        {
+            _configuration.GetSection(OptionsSectionKeyName)
+                .Bind(options);
+        }
+
+        public ValidateOptionsResult Validate(
+            string name,
+            AzureQueueOptions options)
+            => _connectionStringValidator.Validate(
+                options.ConnectionString,
+                options.QueueName);
+    }
+}

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.Common/AzureQueueWrapper.cs
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.Common/AzureQueueWrapper.cs
@@ -1,0 +1,100 @@
+namespace Usain.Samples.Advanced.AzureQueue.Common
+{
+    using System;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure;
+    using Azure.Core;
+    using Azure.Storage.Queues;
+    using Core.Infrastructure;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+    using Slack.Models;
+
+    public class AzureQueueWrapper : IEventQueue<EventWrapper>
+    {
+        private readonly ILogger _logger;
+        private readonly QueueClientOptions _queueClientOptions =
+            new QueueClientOptions();
+        private readonly QueueClient _queueClient;
+        private readonly JsonSerializerOptions _jsonSerializerOptions =
+            new JsonSerializerOptions
+            {
+                IgnoreNullValues = true,
+                WriteIndented = false,
+            };
+
+        public AzureQueueWrapper(
+            ILogger<AzureQueueWrapper> logger,
+            IOptions<AzureQueueOptions> options)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            var currentOptions = options?.Value
+                ?? throw new ArgumentNullException(nameof(options));
+            _queueClientOptions.Retry.Mode = RetryMode.Exponential;
+            _queueClientOptions.Retry.MaxRetries = 3;
+            _queueClient = new QueueClient(
+                currentOptions.ConnectionString,
+                currentOptions.QueueName,
+                _queueClientOptions);
+        }
+
+        public async Task EnqueueAsync(
+            EventWrapper item,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _queueClient.CreateIfNotExistsAsync(
+                    cancellationToken:
+                    cancellationToken);
+                var message = JsonSerializer.Serialize(
+                    item,
+                    _jsonSerializerOptions);
+                await _queueClient.SendMessageAsync(
+                    message,
+                    cancellationToken);
+            }
+            catch (RequestFailedException ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to enqueue event");
+                throw;
+            }
+        }
+
+        public async Task<EventWrapper> DequeueAsync(
+            CancellationToken cancellationToken)
+        {
+            EventWrapper item = null;
+
+            try
+            {
+                var response =
+                    await _queueClient.ReceiveMessagesAsync(cancellationToken); // retrieves 1 message
+                if (response.Value.Length == 0)
+                {
+                    _logger.LogDebug("Queue is empty");
+                    return null;
+                }
+
+                _logger.LogInformation("An event has been dequeued");
+                var messageText = response.Value[0].MessageText;
+                _logger.LogDebug("Dequeued event message: {Message}", messageText);
+                item = JsonSerializer.Deserialize<EventWrapper>(
+                    response.Value[0]
+                        .MessageText);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to dequeue event");
+            }
+
+            return item;
+        }
+    }
+}

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.Common/IAzureQueueConnectionStringValidator.cs
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.Common/IAzureQueueConnectionStringValidator.cs
@@ -1,0 +1,11 @@
+namespace Usain.Samples.Advanced.AzureQueue.Common
+{
+    using Microsoft.Extensions.Options;
+
+    public interface IAzureQueueConnectionStringValidator
+    {
+        ValidateOptionsResult Validate(
+            string connectionString,
+            string queueName);
+    }
+}

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.Common/Usain.Samples.Advanced.AzureQueue.Common.csproj
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.Common/Usain.Samples.Advanced.AzureQueue.Common.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../../../props/common.props"/>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)"/>
+    <PackageReference Include="Azure.Storage.Queues" Version="$(AzureStorageQueuesVersion)"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Usain.Core\Usain.Core.csproj"/>
+    <ProjectReference Include="..\..\..\src\Usain.Slack\Usain.Slack.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/Program.cs
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/Program.cs
@@ -1,0 +1,22 @@
+namespace Usain.Samples.Advanced.AzureQueue.EventListener
+{
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.Hosting;
+
+    public static class Program
+    {
+        public static void Main(
+            string[] args)
+        {
+            CreateHostBuilder(args)
+                .Build()
+                .Run();
+        }
+
+        private static IHostBuilder CreateHostBuilder(
+            string[] args)
+            => Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(
+                    webBuilder => { webBuilder.UseStartup<Startup>(); });
+    }
+}

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/Properties/launchSettings.json
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:4524",
+      "sslPort": 44398
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Usain.Samples.Advanced.AzureQueue.EventListener": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "UsainEventListener__IsRequestAuthenticationEnabled": "false"
+      }
+    }
+  }
+}

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/README.md
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/README.md
@@ -1,0 +1,10 @@
+# AzureQueue EventListener
+
+This project is part of the Advanced AzureQueue Samples.
+
+It demonstrates how to host an Usain EventListener inside a WebHost (ASP.NET Core) application which consumes an [Azure Queue]\
+It works in pair with the Advanced Azure Queue EventProcessor.
+
+
+
+[Azure Queue]: <https://docs.microsoft.com/en-us/azure/storage/queues/>

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/Startup.cs
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/Startup.cs
@@ -1,0 +1,53 @@
+namespace Usain.Samples.Advanced.AzureQueue.EventListener
+{
+    using Common;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Options;
+
+    public class Startup
+    {
+        public void ConfigureServices(
+            IServiceCollection services)
+        {
+            services
+                .AddSingleton<IAzureQueueConnectionStringValidator,
+                    AzureQueueConnectionStringValidator>();
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IValidateOptions
+                    <AzureQueueOptions>, AzureQueueOptions>());
+            services
+                .AddSingleton<IConfigureOptions<AzureQueueOptions>,
+                    AzureQueueOptions>();
+            services.AddUsainEventListener()
+                .AddEventQueue<AzureQueueWrapper>();
+            services.AddOptions();
+        }
+
+        public void Configure(
+            IApplicationBuilder app,
+            IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment()) { app.UseDeveloperExceptionPage(); }
+
+            app.UseHttpsRedirection();
+            app.UseRouting();
+            app.UseUsainEventListener();
+            app.UseEndpoints(
+                endpoints =>
+                {
+                    endpoints.MapGet(
+                        "/",
+                        async context =>
+                        {
+                            await context.Response.WriteAsync(
+                                "Usain Samples - Advanced AzureQueue");
+                        });
+                });
+        }
+    }
+}

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/Usain.Samples.Advanced.AzureQueue.EventListener.csproj
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/Usain.Samples.Advanced.AzureQueue.EventListener.csproj
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <Import Project="../../../props/common.props"/>
+  
+  <PropertyGroup>
+    <UserSecretsId>9509660d-5ecf-4e7e-b7b2-01a02808f8a5</UserSecretsId>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Usain.EventListener\Usain.EventListener.csproj"/>
+    <ProjectReference Include="..\Usain.Samples.Advanced.AzureQueue.Common\Usain.Samples.Advanced.AzureQueue.Common.csproj"/>
+  </ItemGroup>
+</Project>

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/appsettings.Development.json
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/appsettings.json
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventListener/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "UsainEventListener": {
+    "IsRequestAuthenticationEnabled": true,
+    "SigningKey": "***",
+    "DeltaTimeToleranceSeconds": 120
+  },
+  "AzureQueue": {
+    "ConnectionString": "***",
+    "QueueName": "usain-events"
+  }
+}

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventProcessor/Program.cs
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventProcessor/Program.cs
@@ -1,0 +1,45 @@
+﻿namespace Usain.Samples.Advanced.AzureQueue.EventProcessor
+{
+    using System.Threading.Tasks;
+    using Common;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Options;
+
+    class Program
+    {
+        static async Task Main(
+            string[] args)
+        {
+            await CreateHostBuilder(args)
+                .Build()
+                .RunAsync();
+        }
+
+        private static IHostBuilder CreateHostBuilder(
+            string[] args)
+            => Host.CreateDefaultBuilder(args)
+                .ConfigureServices(Configure);
+
+        private static void Configure(
+            IServiceCollection services)
+        {
+            services
+                .AddSingleton<IAzureQueueConnectionStringValidator,
+                    AzureQueueConnectionStringValidator>();
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IValidateOptions
+                    <AzureQueueOptions>, AzureQueueOptions>());
+            services
+                .AddSingleton<IConfigureOptions<AzureQueueOptions>,
+                    AzureQueueOptions>();
+
+            services.AddUsainEventProcessor()
+                .AddEventQueue<AzureQueueWrapper>();
+
+            services.AddLogging();
+            services.AddOptions();
+        }
+    }
+}

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventProcessor/README.md
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventProcessor/README.md
@@ -1,0 +1,9 @@
+# AzureQueue EventProcessor
+
+This project is part of the Advanced Usain Samples.\
+It demonstrates how to host an Usain EventProcessor inside a console application which consumes an [Azure Queue]\
+It works in pair with the Advanced Azure Queue EventProcessor.
+
+
+
+[Azure Queue]: <https://docs.microsoft.com/en-us/azure/storage/queues/>

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventProcessor/Usain.Samples.Advanced.AzureQueue.EventProcessor.csproj
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventProcessor/Usain.Samples.Advanced.AzureQueue.EventProcessor.csproj
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../../../props/common.props"/>
+  
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <UserSecretsId>2b800b27-3c6c-4866-aff7-4b6281387977</UserSecretsId>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Queues" Version="$(AzureStorageQueuesVersion)"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)"/>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Usain.EventProcessor\Usain.EventProcessor.csproj"/>
+    <ProjectReference Include="..\Usain.Samples.Advanced.AzureQueue.Common\Usain.Samples.Advanced.AzureQueue.Common.csproj"/>
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.Development.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventProcessor/appsettings.Development.json
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventProcessor/appsettings.Development.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information",
+      "Microsoft.Hosting.Lifetime": "Debug"
+    }
+  }
+}

--- a/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventProcessor/appsettings.json
+++ b/samples/02.advanced.azurequeue/Usain.Samples.Advanced.AzureQueue.EventProcessor/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "System": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AzureQueue": {
+    "ConnectionString": "***",
+    "QueueName": "usain-events"
+  },
+  "UsainEventProcessor": {
+    "CheckUpdateTimeMs": 3000
+  }
+}


### PR DESCRIPTION
Add a new sample (Advanced AzureQueue) that demonstrates how to run the EventListener
and the EventProcessor in two different processes (hosts).

Both processes communicate (exchange event processing tasks) using
an Azure Queue.