### PR TITLE
fix(slack): stack overflow in CallbackEventConverter

### DIFF
--- a/src/Usain.Slack/JsonConverters/CallbackEventConverter.cs
+++ b/src/Usain.Slack/JsonConverters/CallbackEventConverter.cs
@@ -24,6 +24,15 @@ namespace Usain.Slack.JsonConverters
 
             var eventType = property.GetString();
             Type type = GetEventType(eventType);
+
+            // Avoid infinite recursive behavior of the JsonSerializer
+            // when returning CallbackEvent type (default case).
+            // There is probably a better way.
+            if (type == typeof(CallbackEvent))
+            {
+                return new CallbackEvent { Type = "not_supported" };
+            }
+
             return (CallbackEvent) JsonSerializer.Deserialize(
                 root.GetRawText(),
                 type,

--- a/src/Usain.Slack/JsonConverters/EventBaseConverter.cs
+++ b/src/Usain.Slack/JsonConverters/EventBaseConverter.cs
@@ -25,7 +25,8 @@ namespace Usain.Slack.JsonConverters
             var eventType = property.GetString();
             Type type = GetEventType(eventType);
 
-            // Avoid infinite recursive behavior of the JsonSerializer.
+            // Avoid infinite recursive behavior of the JsonSerializer
+            // when returning Event type (default case).
             // There is probably a better way.
             if (type == typeof(Event))
             {


### PR DESCRIPTION
Fix a stack overflow when CallbackEvent type is unknown or not supported