### PR TITLE
refactor(slack)!: change event namespace

### DIFF
--- a/src/Usain.EventListener/Commands/IngestEvent/IngestEventCommand.cs
+++ b/src/Usain.EventListener/Commands/IngestEvent/IngestEventCommand.cs
@@ -1,6 +1,6 @@
 namespace Usain.EventListener.Commands.IngestEvent
 {
-    using Slack.Models;
+    using Slack.Models.Events;
 
     internal class IngestEventCommand
         : Command<CommandResult>

--- a/src/Usain.EventListener/Commands/IngestEvent/IngestEventCommandHandler.cs
+++ b/src/Usain.EventListener/Commands/IngestEvent/IngestEventCommandHandler.cs
@@ -5,7 +5,7 @@ namespace Usain.EventListener.Commands.IngestEvent
     using System.Threading.Tasks;
     using Core.Infrastructure;
     using Microsoft.Extensions.Logging;
-    using Slack.Models;
+    using Slack.Models.Events;
 
     internal class IngestEventCommandHandler
         : ICommandHandler<IngestEventCommand, CommandResult>

--- a/src/Usain.EventListener/DependencyInjection/EventListenerBuilderExtensions.cs
+++ b/src/Usain.EventListener/DependencyInjection/EventListenerBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
     using Usain.EventListener.Infrastructure.Hosting.Endpoints.ResultGenerators;
     using Usain.EventListener.Infrastructure.Hosting.Middlewares;
     using Usain.EventListener.Infrastructure.Security;
-    using Usain.Slack.Models;
+    using Usain.Slack.Models.Events;
     using Usain.Slack.Security;
     using Endpoint =
         Usain.EventListener.Infrastructure.Hosting.Endpoints.Endpoint;

--- a/src/Usain.EventListener/Infrastructure/Hosting/Endpoints/EventsEndpointHandler.cs
+++ b/src/Usain.EventListener/Infrastructure/Hosting/Endpoints/EventsEndpointHandler.cs
@@ -8,7 +8,7 @@ namespace Usain.EventListener.Infrastructure.Hosting.Endpoints
     using Microsoft.Extensions.Logging;
     using ResultGenerators;
     using Results;
-    using Slack.Models;
+    using Slack.Models.Events;
 
     internal class EventsEndpointHandler : IEndpointHandler
     {

--- a/src/Usain.EventListener/Infrastructure/Hosting/Endpoints/ResultGenerators/AppRateLimitedEventResultGenerator.cs
+++ b/src/Usain.EventListener/Infrastructure/Hosting/Endpoints/ResultGenerators/AppRateLimitedEventResultGenerator.cs
@@ -8,7 +8,7 @@ namespace Usain.EventListener.Infrastructure.Hosting.Endpoints.ResultGenerators
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
     using Results;
-    using Slack.Models;
+    using Slack.Models.Events;
 
     internal class AppRateLimitedEventResultGenerator
         : IEventsEndpointResultGenerator<AppRateLimitedEvent>

--- a/src/Usain.EventListener/Infrastructure/Hosting/Endpoints/ResultGenerators/CallbackEventResultGenerator.cs
+++ b/src/Usain.EventListener/Infrastructure/Hosting/Endpoints/ResultGenerators/CallbackEventResultGenerator.cs
@@ -7,7 +7,7 @@ namespace Usain.EventListener.Infrastructure.Hosting.Endpoints.ResultGenerators
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
     using Results;
-    using Slack.Models;
+    using Slack.Models.Events;
 
     internal class CallbackEventResultGenerator
         : IEventsEndpointResultGenerator<EventWrapper>

--- a/src/Usain.EventListener/Infrastructure/Hosting/Endpoints/ResultGenerators/IEventsEndpointResultGenerator.cs
+++ b/src/Usain.EventListener/Infrastructure/Hosting/Endpoints/ResultGenerators/IEventsEndpointResultGenerator.cs
@@ -3,7 +3,7 @@ namespace Usain.EventListener.Infrastructure.Hosting.Endpoints.ResultGenerators
     using System.Threading;
     using System.Threading.Tasks;
     using Results;
-    using Slack.Models;
+    using Slack.Models.Events;
 
     internal interface IEventsEndpointResultGenerator<in TEvent>
         where TEvent : Event

--- a/src/Usain.EventListener/Infrastructure/Hosting/Endpoints/ResultGenerators/UrlVerificationEventResultGenerator.cs
+++ b/src/Usain.EventListener/Infrastructure/Hosting/Endpoints/ResultGenerators/UrlVerificationEventResultGenerator.cs
@@ -8,7 +8,7 @@ namespace Usain.EventListener.Infrastructure.Hosting.Endpoints.ResultGenerators
     using Microsoft.Extensions.Logging;
     using Results;
     using Results.Responses;
-    using Slack.Models;
+    using Slack.Models.Events;
 
     internal class UrlVerificationEventResultGenerator
         : IEventsEndpointResultGenerator<UrlVerificationEvent>

--- a/src/Usain.EventProcessor/DependencyInjection/EventProcessorBuilderExtensions.cs
+++ b/src/Usain.EventProcessor/DependencyInjection/EventProcessorBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection
     using Usain.EventProcessor.Configuration;
     using Usain.EventProcessor.EventReactions;
     using Usain.EventProcessor.HostedServices;
-    using Usain.Slack.Models;
+    using Usain.Slack.Models.Events;
 
     public static class EventProcessorBuilderExtensions
     {

--- a/src/Usain.EventProcessor/EventReactions/DefaultEventReactionFactory.cs
+++ b/src/Usain.EventProcessor/EventReactions/DefaultEventReactionFactory.cs
@@ -2,8 +2,8 @@ namespace Usain.EventProcessor.EventReactions
 {
     using System;
     using Microsoft.Extensions.Logging;
-    using Slack.Models;
-    using Slack.Models.CallbackEvents;
+    using Slack.Models.Events;
+    using Slack.Models.Events.CallbackEvents;
 
     public class DefaultEventReactionFactory<TCallbackEvent>
         : IEventReactionFactory<TCallbackEvent>

--- a/src/Usain.EventProcessor/EventReactions/EventReactionGenerator.cs
+++ b/src/Usain.EventProcessor/EventReactions/EventReactionGenerator.cs
@@ -1,8 +1,8 @@
 namespace Usain.EventProcessor.EventReactions
 {
     using System;
-    using Slack.Models;
-    using Slack.Models.CallbackEvents;
+    using Slack.Models.Events;
+    using Slack.Models.Events.CallbackEvents;
 
     internal sealed class EventReactionGenerator
         : IEventReactionGenerator

--- a/src/Usain.EventProcessor/EventReactions/IEventReactionFactory.cs
+++ b/src/Usain.EventProcessor/EventReactions/IEventReactionFactory.cs
@@ -1,6 +1,6 @@
 namespace Usain.EventProcessor.EventReactions
 {
-    using Slack.Models;
+    using Slack.Models.Events;
 
     public interface IEventReactionFactory<out TEvent>
         where TEvent : class, new()

--- a/src/Usain.EventProcessor/EventReactions/IEventReactionGenerator.cs
+++ b/src/Usain.EventProcessor/EventReactions/IEventReactionGenerator.cs
@@ -1,6 +1,6 @@
 namespace Usain.EventProcessor.EventReactions
 {
-    using Slack.Models;
+    using Slack.Models.Events;
 
     internal interface IEventReactionGenerator
     {

--- a/src/Usain.EventProcessor/EventReactions/NoopEventReaction.cs
+++ b/src/Usain.EventProcessor/EventReactions/NoopEventReaction.cs
@@ -2,8 +2,8 @@ namespace Usain.EventProcessor.EventReactions
 {
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
-    using Slack.Models;
-    using Slack.Models.CallbackEvents;
+    using Slack.Models.Events;
+    using Slack.Models.Events.CallbackEvents;
 
     internal class NoopEventReaction<TCallbackEvent>
         : IEventReaction<

--- a/src/Usain.EventProcessor/HostedServices/EventQueueProcessor.cs
+++ b/src/Usain.EventProcessor/HostedServices/EventQueueProcessor.cs
@@ -6,7 +6,7 @@ namespace Usain.EventProcessor.HostedServices
     using Core.Infrastructure;
     using EventReactions;
     using Microsoft.Extensions.Logging;
-    using Slack.Models;
+    using Slack.Models.Events;
 
     internal class EventQueueProcessor : IEventQueueProcessor
     {

--- a/src/Usain.Slack/JsonConverters/CallbackEventConverter.cs
+++ b/src/Usain.Slack/JsonConverters/CallbackEventConverter.cs
@@ -3,7 +3,7 @@ namespace Usain.Slack.JsonConverters
     using System;
     using System.Text.Json;
     using System.Text.Json.Serialization;
-    using Models.CallbackEvents;
+    using Models.Events.CallbackEvents;
 
     public class CallbackEventConverter : JsonConverter<CallbackEvent>
     {

--- a/src/Usain.Slack/JsonConverters/EventBaseConverter.cs
+++ b/src/Usain.Slack/JsonConverters/EventBaseConverter.cs
@@ -3,7 +3,7 @@ namespace Usain.Slack.JsonConverters
     using System;
     using System.Text.Json;
     using System.Text.Json.Serialization;
-    using Models;
+    using Models.Events;
 
     public class EventBaseConverter : JsonConverter<Event>
     {

--- a/src/Usain.Slack/JsonConverters/TimestampConverter.cs
+++ b/src/Usain.Slack/JsonConverters/TimestampConverter.cs
@@ -5,9 +5,9 @@ namespace Usain.Slack.JsonConverters
     using System.Text.Json.Serialization;
     using Models;
 
-    public class EventTimestampConverter : JsonConverter<EventTimestamp>
+    public class TimestampConverter : JsonConverter<Timestamp>
     {
-        public override EventTimestamp Read(
+        public override Timestamp Read(
             ref Utf8JsonReader reader,
             Type typeToConvert,
             JsonSerializerOptions options)
@@ -17,13 +17,13 @@ namespace Usain.Slack.JsonConverters
                 throw new JsonException();
             }
 
-            EventTimestamp.TryParse(reader.GetString(), out var eventTimestamp);
+            Timestamp.TryParse(reader.GetString(), out var eventTimestamp);
             return eventTimestamp;
         }
 
         public override void Write(
             Utf8JsonWriter writer,
-            EventTimestamp value,
+            Timestamp value,
             JsonSerializerOptions options)
         {
             writer.WriteStringValue(value.ToString());

--- a/src/Usain.Slack/Models/Events/AppRateLimitedEvent.cs
+++ b/src/Usain.Slack/Models/Events/AppRateLimitedEvent.cs
@@ -1,4 +1,4 @@
-namespace Usain.Slack.Models
+namespace Usain.Slack.Models.Events
 {
     using System.Text.Json.Serialization;
 

--- a/src/Usain.Slack/Models/Events/CallbackEvents/AppMentionEvent.cs
+++ b/src/Usain.Slack/Models/Events/CallbackEvents/AppMentionEvent.cs
@@ -1,4 +1,4 @@
-namespace Usain.Slack.Models.CallbackEvents
+namespace Usain.Slack.Models.Events.CallbackEvents
 {
     using System.Text.Json.Serialization;
 
@@ -8,6 +8,7 @@ namespace Usain.Slack.Models.CallbackEvents
         internal const string TextJsonName = "text";
         internal const string TimestampJsonName = "ts";
         internal const string ChannelJsonName = "channel";
+
         public const string EventType = "app_mention";
 
         [JsonPropertyName(UserJsonName)]
@@ -17,7 +18,7 @@ namespace Usain.Slack.Models.CallbackEvents
         public string? Text { get; set; }
 
         [JsonPropertyName(TimestampJsonName)]
-        public EventTimestamp Timestamp { get; set; } = EventTimestamp.Empty;
+        public Timestamp Timestamp { get; set; } = Timestamp.Empty;
 
         [JsonPropertyName(ChannelJsonName)]
         public string? Channel { get; set; }

--- a/src/Usain.Slack/Models/Events/CallbackEvents/CallbackEvent.cs
+++ b/src/Usain.Slack/Models/Events/CallbackEvents/CallbackEvent.cs
@@ -1,4 +1,4 @@
-namespace Usain.Slack.Models.CallbackEvents
+namespace Usain.Slack.Models.Events.CallbackEvents
 {
     using System.Collections.Generic;
     using System.Text.Json.Serialization;
@@ -34,8 +34,8 @@ namespace Usain.Slack.Models.CallbackEvents
         /// When the event was dispatched
         /// </summary>
         [JsonPropertyName(EventTimestampPropertyName)]
-        public EventTimestamp EventTimestamp { get; set; } =
-            EventTimestamp.Empty;
+        public Timestamp EventTimestamp { get; set; } =
+            Timestamp.Empty;
 
         [JsonExtensionData]
         public Dictionary<string, object> OtherFields { get; set; } =

--- a/src/Usain.Slack/Models/Events/Event.cs
+++ b/src/Usain.Slack/Models/Events/Event.cs
@@ -1,4 +1,4 @@
-namespace Usain.Slack.Models
+namespace Usain.Slack.Models.Events
 {
     using System.Text.Json.Serialization;
     using JsonConverters;

--- a/src/Usain.Slack/Models/Events/EventWrapper.cs
+++ b/src/Usain.Slack/Models/Events/EventWrapper.cs
@@ -1,4 +1,4 @@
-namespace Usain.Slack.Models
+namespace Usain.Slack.Models.Events
 {
     using System.Text.Json.Serialization;
     using CallbackEvents;

--- a/src/Usain.Slack/Models/Events/IChannelEvent.cs
+++ b/src/Usain.Slack/Models/Events/IChannelEvent.cs
@@ -1,4 +1,4 @@
-namespace Usain.Slack.Models
+namespace Usain.Slack.Models.Events
 {
     public interface IChannelEvent
     {

--- a/src/Usain.Slack/Models/Events/UrlVerificationEvent.cs
+++ b/src/Usain.Slack/Models/Events/UrlVerificationEvent.cs
@@ -1,4 +1,4 @@
-namespace Usain.Slack.Models
+namespace Usain.Slack.Models.Events
 {
     using System.Text.Json.Serialization;
 

--- a/src/Usain.Slack/Models/Timestamp.cs
+++ b/src/Usain.Slack/Models/Timestamp.cs
@@ -4,70 +4,70 @@ namespace Usain.Slack.Models
     using System.Text.Json.Serialization;
     using JsonConverters;
 
-    [JsonConverter(typeof(EventTimestampConverter))]
-    public class EventTimestamp : IComparable<EventTimestamp>
+    [JsonConverter(typeof(TimestampConverter))]
+    public class Timestamp : IComparable<Timestamp>
     {
-        public long Timestamp { get; set; }
+        public long Seconds { get; set; }
         public string Suffix { get; set; } = string.Empty;
 
         public bool IsEmpty
-            => Timestamp == 0 && Suffix == string.Empty;
+            => Seconds == 0 && Suffix == string.Empty;
 
-        public static EventTimestamp Empty
-            => new EventTimestamp();
+        public static Timestamp Empty
+            => new Timestamp();
 
         public static bool TryParse(
             string value,
-            out EventTimestamp eventTimestamp)
+            out Timestamp timestamp)
         {
-            eventTimestamp = Empty;
+            timestamp = Empty;
             if (string.IsNullOrWhiteSpace(value)) { return false; }
 
             if (value.IndexOf('.') == -1)
             {
                 return TryParsePartial(
                     value,
-                    out eventTimestamp);
+                    out timestamp);
             }
 
             return TryParseComplete(
                 value,
-                out eventTimestamp);
+                out timestamp);
         }
 
         private static bool TryParsePartial(
             string value,
-            out EventTimestamp eventTimestamp)
+            out Timestamp timestamp)
         {
-            eventTimestamp = Empty;
+            timestamp = Empty;
             if (!long.TryParse(
                 value,
-                out var timestamp)) { return false; }
+                out var seconds)) { return false; }
 
-            eventTimestamp.Timestamp = timestamp;
+            timestamp.Seconds = seconds;
             return true;
         }
 
         private static bool TryParseComplete(
             string value,
-            out EventTimestamp eventTimestamp)
+            out Timestamp timestamp)
         {
-            eventTimestamp = Empty;
+            timestamp = Empty;
             var parts = value.Split(
                 '.',
                 StringSplitOptions.RemoveEmptyEntries);
             if (!long.TryParse(
                 parts[0],
-                out var timestamp)) { return false; }
+                out var seconds)) { return false; }
 
-            eventTimestamp.Timestamp = timestamp;
-            if (parts.Length == 2) { eventTimestamp.Suffix = parts[1]; }
+            timestamp.Seconds = seconds;
+            if (parts.Length == 2) { timestamp.Suffix = parts[1]; }
 
             return true;
         }
 
         public int CompareTo(
-            EventTimestamp? other)
+            Timestamp? other)
         {
             if (ReferenceEquals(
                 this,
@@ -76,7 +76,7 @@ namespace Usain.Slack.Models
                 null,
                 other)) return 1;
 
-            var timestampComparison = Timestamp.CompareTo(other.Timestamp);
+            var timestampComparison = Seconds.CompareTo(other.Seconds);
             if (timestampComparison != 0) return timestampComparison;
 
             return string.Compare(
@@ -86,6 +86,6 @@ namespace Usain.Slack.Models
         }
 
         public override string ToString()
-            => $"{Timestamp}{(string.IsNullOrEmpty(Suffix) ? "" : ".")}{Suffix}";
+            => $"{Seconds}{(string.IsNullOrEmpty(Suffix) ? "" : ".")}{Suffix}";
     }
 }

--- a/tests/integration/Usain.EventListener.Integration.Tests/AppMentionTest.cs
+++ b/tests/integration/Usain.EventListener.Integration.Tests/AppMentionTest.cs
@@ -7,7 +7,7 @@ namespace Usain.EventListener.Integration.Tests
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.TestHost;
     using Microsoft.Extensions.Hosting;
-    using Slack.Models.CallbackEvents;
+    using Slack.Models.Events.CallbackEvents;
     using Xunit;
 
     public class AppMentionTest

--- a/tests/integration/Usain.EventListener.Integration.Tests/AppRateLimitedTest.cs
+++ b/tests/integration/Usain.EventListener.Integration.Tests/AppRateLimitedTest.cs
@@ -7,8 +7,7 @@ namespace Usain.EventListener.Integration.Tests
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.TestHost;
     using Microsoft.Extensions.Hosting;
-    using Slack.Models;
-    using Snapper;
+    using Slack.Models.Events;
     using Xunit;
 
     public class AppRateLimitedTest

--- a/tests/integration/Usain.EventListener.Integration.Tests/Helpers/InMemoryEventQueue.cs
+++ b/tests/integration/Usain.EventListener.Integration.Tests/Helpers/InMemoryEventQueue.cs
@@ -4,7 +4,7 @@ namespace Usain.EventListener.Integration.Tests.Helpers
     using System.Threading;
     using System.Threading.Tasks;
     using Core.Infrastructure;
-    using Slack.Models;
+    using Slack.Models.Events;
 
     public class InMemoryEventQueue : IEventQueue<EventWrapper>
     {

--- a/tests/integration/Usain.EventListener.Integration.Tests/UrlVerificationTest.cs
+++ b/tests/integration/Usain.EventListener.Integration.Tests/UrlVerificationTest.cs
@@ -7,7 +7,7 @@ namespace Usain.EventListener.Integration.Tests
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.TestHost;
     using Microsoft.Extensions.Hosting;
-    using Slack.Models;
+    using Slack.Models.Events;
     using Snapper;
     using Xunit;
 

--- a/tests/unit/Usain.EventListener.Tests/Commands/IngestEvent/IngestEventCommandHandlerTest.cs
+++ b/tests/unit/Usain.EventListener.Tests/Commands/IngestEvent/IngestEventCommandHandlerTest.cs
@@ -7,7 +7,7 @@ namespace Usain.EventListener.Tests.Commands.IngestEvent
     using EventListener.Commands.IngestEvent;
     using Microsoft.Extensions.Logging;
     using Moq;
-    using Slack.Models;
+    using Slack.Models.Events;
     using Xunit;
 
     public class IngestEventCommandHandlerTest

--- a/tests/unit/Usain.EventListener.Tests/Infrastructure/Hosting/Endpoints/EndpointRouterTest.cs
+++ b/tests/unit/Usain.EventListener.Tests/Infrastructure/Hosting/Endpoints/EndpointRouterTest.cs
@@ -7,7 +7,7 @@ namespace Usain.EventListener.Tests.Infrastructure.Hosting.Endpoints
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
     using Moq;
-    using Slack.Models;
+    using Slack.Models.Events;
     using Xunit;
     using Endpoint = EventListener.Infrastructure.Hosting.Endpoints.Endpoint;
 

--- a/tests/unit/Usain.EventListener.Tests/Infrastructure/Hosting/Endpoints/EventsEndpointHandlerTest.cs
+++ b/tests/unit/Usain.EventListener.Tests/Infrastructure/Hosting/Endpoints/EventsEndpointHandlerTest.cs
@@ -11,7 +11,7 @@ namespace Usain.EventListener.Tests.Infrastructure.Hosting.Endpoints
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
     using Moq;
-    using Slack.Models;
+    using Slack.Models.Events;
     using Xunit;
 
     public class EventsEndpointHandlerTest

--- a/tests/unit/Usain.EventListener.Tests/Infrastructure/Hosting/Endpoints/ResultGenerators/AppRateLimitedEventResultGeneratorTest.cs
+++ b/tests/unit/Usain.EventListener.Tests/Infrastructure/Hosting/Endpoints/ResultGenerators/AppRateLimitedEventResultGeneratorTest.cs
@@ -12,7 +12,7 @@ namespace Usain.EventListener.Tests.Infrastructure.Hosting.Endpoints.
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
     using Moq;
-    using Slack.Models;
+    using Slack.Models.Events;
     using Xunit;
 
     public class AppRateLimitedEventResultGeneratorTest

--- a/tests/unit/Usain.EventListener.Tests/Infrastructure/Hosting/Endpoints/ResultGenerators/CallbackEventResultGeneratorTest.cs
+++ b/tests/unit/Usain.EventListener.Tests/Infrastructure/Hosting/Endpoints/ResultGenerators/CallbackEventResultGeneratorTest.cs
@@ -12,7 +12,7 @@ namespace Usain.EventListener.Tests.Infrastructure.Hosting.Endpoints.
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
     using Moq;
-    using Slack.Models;
+    using Slack.Models.Events;
     using Xunit;
 
     public class CallbackEventResultGeneratorTest

--- a/tests/unit/Usain.EventListener.Tests/Infrastructure/Hosting/Endpoints/ResultGenerators/UrlVerificationEventResultGeneratorTest.cs
+++ b/tests/unit/Usain.EventListener.Tests/Infrastructure/Hosting/Endpoints/ResultGenerators/UrlVerificationEventResultGeneratorTest.cs
@@ -13,7 +13,7 @@ namespace Usain.EventListener.Tests.Infrastructure.Hosting.Endpoints.
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
     using Moq;
-    using Slack.Models;
+    using Slack.Models.Events;
     using Xunit;
 
     public class UrlVerificationEventResultGeneratorTest

--- a/tests/unit/Usain.EventProcessor.Tests/DependencyInjection/EventProcessorBuilderExtensionsTest.cs
+++ b/tests/unit/Usain.EventProcessor.Tests/DependencyInjection/EventProcessorBuilderExtensionsTest.cs
@@ -10,7 +10,7 @@ namespace Usain.EventProcessor.Tests.DependencyInjection
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Options;
     using Moq;
-    using Slack.Models;
+    using Slack.Models.Events;
     using Xunit;
 
     public class EventProcessorBuilderExtensionsTest

--- a/tests/unit/Usain.EventProcessor.Tests/EventReactions/DefaultEventReactionFactoryTest.cs
+++ b/tests/unit/Usain.EventProcessor.Tests/EventReactions/DefaultEventReactionFactoryTest.cs
@@ -3,8 +3,8 @@ namespace Usain.EventProcessor.Tests.EventReactions
     using EventProcessor.EventReactions;
     using Microsoft.Extensions.Logging;
     using Moq;
-    using Slack.Models;
-    using Slack.Models.CallbackEvents;
+    using Slack.Models.Events;
+    using Slack.Models.Events.CallbackEvents;
     using Xunit;
 
     public class DefaultEventReactionFactoryTest

--- a/tests/unit/Usain.EventProcessor.Tests/EventReactions/EventReactionGeneratorTest.cs
+++ b/tests/unit/Usain.EventProcessor.Tests/EventReactions/EventReactionGeneratorTest.cs
@@ -3,8 +3,8 @@ namespace Usain.EventProcessor.Tests.EventReactions
     using System;
     using EventProcessor.EventReactions;
     using Moq;
-    using Slack.Models;
-    using Slack.Models.CallbackEvents;
+    using Slack.Models.Events;
+    using Slack.Models.Events.CallbackEvents;
     using Xunit;
 
     public class EventReactionGeneratorTest

--- a/tests/unit/Usain.EventProcessor.Tests/EventReactions/NoopEventReactionTest.cs
+++ b/tests/unit/Usain.EventProcessor.Tests/EventReactions/NoopEventReactionTest.cs
@@ -4,8 +4,8 @@ namespace Usain.EventProcessor.Tests.EventReactions
     using EventProcessor.EventReactions;
     using Microsoft.Extensions.Logging;
     using Moq;
-    using Slack.Models;
-    using Slack.Models.CallbackEvents;
+    using Slack.Models.Events;
+    using Slack.Models.Events.CallbackEvents;
     using Xunit;
 
     public class NoopEventReactionTest

--- a/tests/unit/Usain.EventProcessor.Tests/HostedServices/EventQueueProcessorTest.cs
+++ b/tests/unit/Usain.EventProcessor.Tests/HostedServices/EventQueueProcessorTest.cs
@@ -7,8 +7,8 @@ namespace Usain.EventProcessor.Tests.HostedServices
     using EventProcessor.HostedServices;
     using Microsoft.Extensions.Logging;
     using Moq;
-    using Slack.Models;
-    using Slack.Models.CallbackEvents;
+    using Slack.Models.Events;
+    using Slack.Models.Events.CallbackEvents;
     using Xunit;
 
     public class EventQueueProcessorTest

--- a/tests/unit/User.Slack.Tests/JsonConverters/CallbackEventConverterTest.cs
+++ b/tests/unit/User.Slack.Tests/JsonConverters/CallbackEventConverterTest.cs
@@ -7,7 +7,7 @@ namespace User.Slack.Tests.JsonConverters
     using System.Text.Json;
     using Usain.Slack.JsonConverters;
     using Usain.Slack.Models;
-    using Usain.Slack.Models.CallbackEvents;
+    using Usain.Slack.Models.Events.CallbackEvents;
     using Xunit;
 
     public class CallbackEventConverterTest
@@ -20,7 +20,7 @@ namespace User.Slack.Tests.JsonConverters
             typeof(EmptyTestObject),
             false)]
         [InlineData(
-            typeof(EventTimestamp),
+            typeof(Timestamp),
             false)]
         [InlineData(
             typeof(CallbackEvent),
@@ -95,10 +95,10 @@ namespace User.Slack.Tests.JsonConverters
                     Text = "text",
                     Type = AppMentionEvent.EventType,
                     User = "user",
-                    Timestamp = new EventTimestamp
-                        { Suffix = "006", Timestamp = 123456, },
-                    EventTimestamp = new EventTimestamp
-                        { Suffix = "006", Timestamp = 123456, },
+                    Timestamp = new Timestamp
+                        { Suffix = "006", Seconds = 123456, },
+                    EventTimestamp = new Timestamp
+                        { Suffix = "006", Seconds = 123456, },
                 },
                 "{\"user\":\"user\",\"text\":\"text\",\"ts\":\"123456.006\",\"channel\":\"channel\",\"type\":\"app_mention\",\"event_ts\":\"123456.006\"}",
             };
@@ -111,10 +111,10 @@ namespace User.Slack.Tests.JsonConverters
                     Text = "text",
                     Type = AppMentionEvent.EventType,
                     User = "user",
-                    Timestamp = new EventTimestamp
-                        { Suffix = "006", Timestamp = 123456, },
-                    EventTimestamp = new EventTimestamp
-                        { Suffix = "006", Timestamp = 123456, },
+                    Timestamp = new Timestamp
+                        { Suffix = "006", Seconds = 123456, },
+                    EventTimestamp = new Timestamp
+                        { Suffix = "006", Seconds = 123456, },
                 },
                 "{\"user\":\"user\",\"text\":\"text\",\"ts\":\"123456.006\",\"channel\":\"channel\",\"type\":\"app_mention\",\"event_ts\":\"123456.006\"}",
             };
@@ -124,8 +124,8 @@ namespace User.Slack.Tests.JsonConverters
                 new CallbackEvent
                 {
                     Type = "callback_event",
-                    EventTimestamp = new EventTimestamp
-                        { Suffix = "006", Timestamp = 123456 },
+                    EventTimestamp = new Timestamp
+                        { Suffix = "006", Seconds = 123456 },
                 },
                 "{\"type\":\"callback_event\",\"event_ts\":\"123456.006\"}",
             };

--- a/tests/unit/User.Slack.Tests/JsonConverters/EventBaseConverterTest.cs
+++ b/tests/unit/User.Slack.Tests/JsonConverters/EventBaseConverterTest.cs
@@ -5,8 +5,8 @@ namespace User.Slack.Tests.JsonConverters
     using System.Text;
     using System.Text.Json;
     using Usain.Slack.JsonConverters;
-    using Usain.Slack.Models;
-    using Usain.Slack.Models.CallbackEvents;
+    using Usain.Slack.Models.Events;
+    using Usain.Slack.Models.Events.CallbackEvents;
     using Xunit;
 
     public class EventBaseConverterTest

--- a/tests/unit/User.Slack.Tests/JsonConverters/TimestampConverterTest.cs
+++ b/tests/unit/User.Slack.Tests/JsonConverters/TimestampConverterTest.cs
@@ -7,7 +7,7 @@ namespace User.Slack.Tests.JsonConverters
     using Usain.Slack.Models;
     using Xunit;
 
-    public class EventTimestampConverterTest
+    public class TimestampConverterTest
     {
         private const string JsonData = "{\"prop\":\"1591452219.000400\"}";
 
@@ -21,7 +21,7 @@ namespace User.Slack.Tests.JsonConverters
 
             Assert.Equal(
                 1591452219,
-                actual.Timestamp);
+                actual.Seconds);
             Assert.Equal(
                 "000400",
                 actual.Suffix);
@@ -56,10 +56,10 @@ namespace User.Slack.Tests.JsonConverters
         {
             using var stream = new MemoryStream();
             using var writer = new Utf8JsonWriter(stream);
-            var converter = new EventTimestampConverter();
+            var converter = new TimestampConverter();
             converter.Write(
                 writer,
-                new EventTimestamp() { Suffix = suffix, Timestamp = timestamp },
+                new Timestamp() { Suffix = suffix, Seconds = timestamp },
                 _options);
             writer.Flush();
 
@@ -70,7 +70,7 @@ namespace User.Slack.Tests.JsonConverters
                 actual);
         }
 
-        private EventTimestamp ExecuteRead(
+        private Timestamp ExecuteRead(
             string json,
             JsonTokenType tokenType = JsonTokenType.String)
         {
@@ -78,9 +78,9 @@ namespace User.Slack.Tests.JsonConverters
                 new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
             while (reader.TokenType != tokenType) { reader.Read(); }
 
-            return new EventTimestampConverter().Read(
+            return new TimestampConverter().Read(
                 ref reader,
-                typeof(EventTimestamp), // This is not used, use anything
+                typeof(Timestamp), // This is not used, use anything
                 _options);
         }
     }

--- a/tests/unit/User.Slack.Tests/Models/TimestampTest.cs
+++ b/tests/unit/User.Slack.Tests/Models/TimestampTest.cs
@@ -3,7 +3,7 @@ namespace User.Slack.Tests.Models
     using Usain.Slack.Models;
     using Xunit;
 
-    public class EventTimestampTest
+    public class TimestampTest
     {
         public const long Timestamp = 1591452219;
         public const string Suffix = "0001";
@@ -26,9 +26,9 @@ namespace User.Slack.Tests.Models
             string suffix,
             bool expected)
         {
-            var eventTimestamp = new EventTimestamp
+            var eventTimestamp = new Timestamp
             {
-                Timestamp = timestamp,
+                Seconds = timestamp,
                 Suffix = suffix,
             };
             Assert.Equal(
@@ -39,10 +39,10 @@ namespace User.Slack.Tests.Models
         [Fact]
         public void Empty_Returns_Empty_Timestamp()
         {
-            var actual = EventTimestamp.Empty;
+            var actual = Usain.Slack.Models.Timestamp.Empty;
             Assert.Equal(
                 0,
-                actual.Timestamp);
+                actual.Seconds);
             Assert.Empty(actual.Suffix);
         }
 
@@ -64,9 +64,9 @@ namespace User.Slack.Tests.Models
             string suffix,
             bool areEqual)
         {
-            var expectedTs = new EventTimestamp
+            var expectedTs = new Timestamp
             {
-                Timestamp = Timestamp,
+                Seconds = Timestamp,
                 Suffix = Suffix,
             };
 
@@ -74,14 +74,14 @@ namespace User.Slack.Tests.Models
                 areEqual,
                 0
                 == expectedTs.CompareTo(
-                    new EventTimestamp
-                        { Timestamp = timestamp, Suffix = suffix }));
+                    new Timestamp
+                        { Seconds = timestamp, Suffix = suffix }));
         }
 
         [Fact]
         public void CompareTo_Equal_Self()
         {
-            var timestamp = new EventTimestamp();
+            var timestamp = new Timestamp();
             Assert.Equal(
                 0,
                 timestamp.CompareTo(timestamp));
@@ -92,7 +92,7 @@ namespace User.Slack.Tests.Models
         {
             Assert.NotEqual(
                 0,
-                new EventTimestamp().CompareTo(null));
+                new Timestamp().CompareTo(null));
         }
 
         [Theory]
@@ -103,7 +103,7 @@ namespace User.Slack.Tests.Models
             string value)
         {
             Assert.False(
-                EventTimestamp.TryParse(
+                Usain.Slack.Models.Timestamp.TryParse(
                     value,
                     out _));
         }
@@ -129,7 +129,7 @@ namespace User.Slack.Tests.Models
             string value,
             string expected)
         {
-            EventTimestamp.TryParse(
+            Usain.Slack.Models.Timestamp.TryParse(
                 value,
                 out var eventTimeStamp);
 


### PR DESCRIPTION
* Change event namespace
* Rename EventTimestamp type to Timestamp

BREAKING CHANGE: EventTimestamp type has been renamed to Timestamp